### PR TITLE
Make changes to the default ggplot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config.R
 
 /.quarto/
 /_site/
+.Rproj.user

--- a/editing-figures-in-r.qmd
+++ b/editing-figures-in-r.qmd
@@ -9,6 +9,8 @@ title-block-banner-color: white
 execute:
   echo: false
   code-overflow: wrap
+editor_options: 
+  chunk_output_type: console
 ---
 
 # Editing Figures in R
@@ -42,15 +44,12 @@ Next, you will need to find the figure that requires editing or formatting work.
 #| echo: false
 
 library(tidyverse)
+library(urbnthemes)
 library(knitr)
 library(kableExtra)
-library(urbnthemes)
 library(grid)
 library(gridExtra)
 library(formattable)
-library(kableExtra)
-library(ggplot2)
-library(dplyr)
 library(scales)
 library(extrafont)
 
@@ -84,38 +83,35 @@ decimal_to_percentage <- function(x) {
 ::: {.panel-tabset}
 ## Figure 1
 ```{r ggplot-chart}
+set_urbn_defaults(style = "print")
 
 #With custom parameters applied
-
-ggplot(df_fig2_long, aes(x = Category, y = Value, fill = Series)) +
-  geom_bar(stat = "identity", position = position_dodge()) +
-  labs(y = "Percent", x = "", fill = "") +
-  scale_fill_discrete(labels = c('Current funding and participation', 
-  'Full funding and participation in SSI, SNAP, WIC, TANF, CCDF, LIHEAP, and housing')) +
-  geom_text(aes(label = decimal_to_percentage(Value)), 
-            vjust = -0.5, 
-            position = position_dodge2(width = 0.7, padding = 0.5),
-            size = 2,
-            color = "black", 
-            family = "Lato") +
-  scale_y_continuous(expand = expansion(mult = 0), 
-                     limits = c(0, max(df_fig2_long$Value) * 1.5), 
-                     labels = decimal_to_percentage) +
-  theme_bw() +
-  theme(legend.position = "top", 
-        legend.justification = "left", 
-        legend.margin = margin(t = -8), 
-        plot.margin = unit(c(1, 0, 0, 0), "lines"), 
-        axis.title.y = element_text(size = 7, family = "Lato", colour = "black"), 
-        axis.text.x = element_text(size = 8, family = "Lato", colour = "black"), 
-        axis.text.y = element_text(size = 8, family = "Lato", colour = "black"), 
-        legend.text = element_text(size = 7), 
-        legend.title = element_text(size = 7), 
-        panel.border = element_blank(), 
-        panel.grid.major = element_blank(),
-        panel.grid.minor = element_blank(), 
-        axis.line = element_line(colour = "black")) +
-  guides(fill = guide_legend(title = ""))
+df_fig2_long %>%
+  mutate(Value = Value / 100) %>%
+  mutate(
+    Series = case_match(
+      Series,
+        "Full.funding.and.participation.in.SSI..SNAP..WIC..TANF..CCDF..LIHEAP..and.housing." ~ "Full funding and participation in SSI, SNAP, WIC, TANF, CCDF, LIHEAP, and housing",
+      "Baseline" ~ "Current funding and participation"
+    )
+  ) %>%
+  ggplot(mapping = aes(x = Category, y = Value, fill = Series)) +
+  geom_col(position = position_dodge()) +
+  geom_text(
+    mapping = aes(label = label_percent(accuracy = 0.1)(Value)), 
+    vjust = -0.5, 
+    position = position_dodge2(width = 0.7, padding = 0.5),
+    size = 2
+  ) +
+  scale_y_continuous(
+    expand = expansion(mult = c(0, 0.3)),
+    labels = label_percent()
+  ) +
+  labs(
+    x = NULL, 
+    y = "Percent", 
+    fill = NULL
+  )
 
 ```
 

--- a/r-and-git-for-editors.Rproj
+++ b/r-and-git-for-editors.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX


### PR DESCRIPTION
I think this is an incredibly valuable reason and I am committed to helping in any way I can to make it reach its potential. 

I updated the base ggplot in `editing-figures-in-r.qmd`. You shouldn't need to do much customization if you correctly use `library(urbnthemes)`. The [R graphics guide](https://urbaninstitute.github.io/r-at-urban/graphics-guide.html) contains extensive examples. Please let me know if urbnthemes or any of the examples need updating to better align with Urban Institute standards. 

I couldn't render the entire document as-is. You can see much changes in the diffs and here is a brief summary:

1. I added `set_urbn_defaults()`, which should minimize the need to use `theme_bw()` and `theme()`. 
2. Use `geom_col()` when the data is already summarized. This is the same as `geom_bar(stat = "identity")` with less typing. 
3. I try to use a consistent order with ggplot: `ggplot()`, geoms, scales, labels, themes.
4. `NULL` is better than `""` for dropping text because it repurposes the space instead of leaving blanks. 
5. I always recommend changing the data instead of adding labels in ggplot. Adding labels runs the risks of errors. In fact, in this case we can change the data once and then the changes will propagate through all of the examples. 
6. Don't need `guides()` if we use `labs()`
8. We can use asymmetric `expansion()` instead of writing code to set the limits. 
